### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/src/main/java/org/commoncrawl/util/shared/Filter.java
+++ b/src/main/java/org/commoncrawl/util/shared/Filter.java
@@ -63,7 +63,7 @@ public abstract class Filter {
 
   // murmur is faster than a sha-based approach and provides as-good collision
   // resistance. the combinatorial generation approach described in
-  // http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
+  // https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf
   // does prove to work in actual tests, and is obviously faster
   // than performing further iterations of murmur.
   static int[] getHashBuckets(String key, int hashCount, int max) {


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author